### PR TITLE
Update main.yml

### DIFF
--- a/roles/linux-wls/tasks/main.yml
+++ b/roles/linux-wls/tasks/main.yml
@@ -8,14 +8,14 @@
 # ==> Configure Linux
 - name: Install required libraries
   yum: name={{ item }} state=present
-  with_items: packages_list
+  with_items: '{{ packages_list }}'
 - name: Disable SELinux
   selinux: state=disabled
 - name: Disable Firewall Deamon (firewalld)
   service: name=firewalld state=stopped enabled=no
 - name: Change kernel parameters
   sysctl: name="{{ item.key }}" value="{{ item.value }}" state=present
-  with_dict: kernel_params
+  with_dict: '{{ kernel_params }}'
 
 # ==> Create user and groups
 - name: Create groups


### PR DESCRIPTION
Ansible 2.6.4 requires the references to the var and dict elements to be in curly braces